### PR TITLE
Consider more code content to be links

### DIFF
--- a/qml/js/Utils.js
+++ b/qml/js/Utils.js
@@ -56,7 +56,7 @@ function isVevent(text) {
 
 function isLink(text) {
     if (text !== "") {
-        var urls = text.match(/^(http[s]*:\/\/.{3,500}|www\..{3,500}|sms:.*)$/)
+        var urls = text.match(/^([a-z]{3,10}:\/\/.{3,500}|www\..{3,500}|sms:.*)$/)
         return urls && urls.length > 0
     }
     return false


### PR DESCRIPTION
Before only http(s):// (plus some special cases) were considered links, now a code containing any 3-10 lowercase a-z characters followed by :// is considered to be a URL/link.
